### PR TITLE
Removed 'required' from validation

### DIFF
--- a/app/Http/Requests/AnswerRequest.php
+++ b/app/Http/Requests/AnswerRequest.php
@@ -21,8 +21,12 @@ class AnswerRequest extends FormRequest
      */
     public function rules(): array
     {
+//        return [
+//            'text' => 'required',
+//            'question_id' => 'required|exists:questions,id',
+//        ];
         return [
-            'text' => 'required',
+            'text' => '',
             'question_id' => 'required|exists:questions,id',
         ];
     }

--- a/app/Http/Requests/QuestionGroupRequest.php
+++ b/app/Http/Requests/QuestionGroupRequest.php
@@ -21,12 +21,20 @@ class QuestionGroupRequest extends FormRequest
      */
     public function rules(): array
     {
+//        return [
+//            'title' => 'required',
+//            'disqualify_amount' => 'required|integer',
+//            'answer_time' => 'required',
+//            'points' => 'required|integer',
+//            'is_additional' => 'required|boolean',
+//            'quiz_id' => 'required|exists:quizzes,id',
+//        ];
         return [
-            'title' => 'required',
-            'disqualify_amount' => 'required|integer',
-            'answer_time' => 'required',
-            'points' => 'required|integer',
-            'is_additional' => 'required|boolean',
+            'title' => '',
+            'disqualify_amount' => 'integer',
+            'answer_time' => '',
+            'points' => 'integer',
+            'is_additional' => 'boolean',
             'quiz_id' => 'required|exists:quizzes,id',
         ];
     }

--- a/app/Http/Requests/QuestionRequest.php
+++ b/app/Http/Requests/QuestionRequest.php
@@ -21,8 +21,14 @@ class QuestionRequest extends FormRequest
      */
     public function rules(): array
     {
+//        return [
+//            'text' => 'required',
+//            'image' => 'nullable',
+//            'question_group_id' => 'required|exists:question_groups,id',
+//        ];
+
         return [
-            'text' => 'required',
+            'text' => '',
             'image' => 'nullable',
             'question_group_id' => 'required|exists:question_groups,id',
         ];

--- a/database/migrations/2024_03_13_221629_create_question_groups_table.php
+++ b/database/migrations/2024_03_13_221629_create_question_groups_table.php
@@ -13,11 +13,11 @@ return new class extends Migration
     {
         Schema::create('question_groups', function (Blueprint $table) {
             $table->id();
-            $table->string("title");
-            $table->integer("disqualify_amount");
-            $table->float("answer_time");
-            $table->integer("points");
-            $table->boolean("is_additional")->default(false);
+            $table->string("title")->nullable();
+            $table->integer("disqualify_amount")->nullable();
+            $table->float("answer_time")->nullable();
+            $table->integer("points")->nullable();
+            $table->boolean("is_additional")->default(false)->nullable();
             $table->foreignId("quiz_id")->constrained()->onDelete('cascade');
             $table->timestamps();
         });

--- a/database/migrations/2024_03_13_222444_create_questions_table.php
+++ b/database/migrations/2024_03_13_222444_create_questions_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('questions', function (Blueprint $table) {
             $table->id();
-            $table->string("text");
+            $table->string("text")->nullable();
             $table->string("image")->nullable();
             $table->foreignId("question_group_id")->constrained()->cascadeOnDelete();
             $table->timestamps();

--- a/database/migrations/2024_03_17_104422_create_answers_table.php
+++ b/database/migrations/2024_03_17_104422_create_answers_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('answers', function (Blueprint $table) {
             $table->id();
-            $table->string("text");
-            $table->boolean("is_correct")->default(false);
+            $table->string("text")->nullable();
+            $table->boolean("is_correct")->default(false)->nullable();
             $table->foreignId("question_id")->constrained()->cascadeOnDelete();
             $table->timestamps();
         });


### PR DESCRIPTION
Temporarily removed 'required' tags from validation for all models used in the question editor.
Kept the 'required' tags on FK fields.

Remember to migrate:fresh --seed :)